### PR TITLE
fix npm install on m1, remove unused fiber dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "axios": "^0.19.0",
         "copy-to-clipboard": "^3.3.1",
         "core-js": "^3.4.2",
-        "fiber": "^1.0.4",
         "register-service-worker": "^1.6.2",
         "vue": "^2.6.10",
         "vue-carousel": "^0.18.0",
@@ -8554,14 +8553,6 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fiber": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fiber/-/fiber-1.0.4.tgz",
-      "integrity": "sha1-aZ6cWBcdaFsaNpyY10M5aRMzKN4=",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/figgy-pudding": {
@@ -27085,11 +27076,6 @@
       "requires": {
         "bser": "2.1.1"
       }
-    },
-    "fiber": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fiber/-/fiber-1.0.4.tgz",
-      "integrity": "sha1-aZ6cWBcdaFsaNpyY10M5aRMzKN4="
     },
     "figgy-pudding": {
       "version": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "axios": "^0.19.0",
     "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.4.2",
-    "fiber": "^1.0.4",
     "register-service-worker": "^1.6.2",
     "vue": "^2.6.10",
     "vue-carousel": "^0.18.0",


### PR DESCRIPTION
Project crash on M1 mac, due to fiber dependency.

reference from [disfactory commit](https://github.com/Disfactory/frontend/commit/10aa31b15b8b3ae0cc548235393b0386d0c143fc)